### PR TITLE
Made instantiateJob() protected and cleaned it up a bit

### DIFF
--- a/src/JobRunner.php
+++ b/src/JobRunner.php
@@ -129,26 +129,27 @@ class JobRunner
 		return $job_list;
 	}
 
-	private function instantiateJob($job_name, $job_list)
+	/**
+	 * Instantiates a job class (if it's indeed a job), and adds it to the
+	 * provided job list.
+	 *
+	 * @param string $job_name The fully qualified path to the class.
+	 * @param array  $job_list Array of jobs already instantiated.
+	 * @return array Updated $job_list.
+	 */
+	protected function instantiateJob($job_name, array $job_list)
 	{
 		if (is_subclass_of($job_name, 'Barracuda\\JobRunner\\Job'))
 		{
 			$job = new $job_name($this->logger);
 
-			// Another sanity check
-			if ($job instanceof Job)
-			{
-				$job_list[$job->getShortName()] = $job;
-			}
-			else
-			{
-				$this->logger->info($job_name . ' is not an instance of Job, skipping.');
-			}
+			$job_list[$job->getShortName()] = $job;
 		}
 		else
 		{
-			$this->logger->info($job_name . ' is not an instance of Job, skipping.');
+			$this->logger->warning($job_name . ' is not a subclass of Job, skipping.');
 		}
+
 		return $job_list;
 	}
 


### PR DESCRIPTION
This is how I plan to override it:

``` php
    /**
     * Creates an instance of a given Job class.
     *
     * @param string $job_class Fully-qualified path to the job class.
     * @param array  $job_list  List of instantiated jobs.
     * @return array Updated $job_list.
     */
    protected function instantiateJob($job_class, array $job_list)
    {
        if (!is_subclass_of($job_class, Job::class))
        {
            $this->logger->warning($job_class . ' is not a subclass of ' . Job::class . ', skipping.');
            return $job_list;
        }

        $job = $this->app->make($job_class);

        return [$job->getShortName() => $job] + $job_list;
    }
```
