### PR TITLE
Add enabled/disabled logging in addJob()

### DIFF
--- a/src/JobRunner.php
+++ b/src/JobRunner.php
@@ -80,7 +80,8 @@ class JobRunner
 		$this->jobs[$class] = $definition;
 		$this->createJobBuckets($class);
 
-		$this->logger->info("Registered job {$reflection->getShortName()}");
+		$this->logger->info("Registered job {$reflection->getShortName()} -- " .
+			($definition->getEnabled() ? "enabled" : "disabled"));
 	}
 
 	/**


### PR DESCRIPTION
Simply adds either " -- enabled" or " -- disabled" to the end of the "Registered job" log.
