### PR TITLE
Changing the visibility of fork_daemon property from private to prote…

### DIFF
--- a/src/JobRunner.php
+++ b/src/JobRunner.php
@@ -24,7 +24,7 @@ class JobRunner
 	/**
 	 * @var \fork_daemon
 	 */
-	private $fork_daemon;
+	protected $fork_daemon;
 
 	/**
 	 * @param \fork_daemon    $fork_daemon Instance of ForkDaemon.


### PR DESCRIPTION
In a class that extends this awesome library, I really needed the fork_daemon instance to be able to spawn some children for a completely different type of job. so, that would be great if we can have this property visible.
